### PR TITLE
add administrative area fields

### DIFF
--- a/Document/Address.php
+++ b/Document/Address.php
@@ -55,6 +55,16 @@ class Address
     protected $country;
 
     /**
+     * @ORM\Column(type="string")
+     */
+    protected $administrativeAreaLevel1;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $administrativeAreaLevel2;
+
+    /**
      * @PHPCR\Float()
      * @AddressValidator\Latitude()
      */
@@ -319,5 +329,37 @@ class Address
         $this->longitude = $longitude;
 
         return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel1()
+    {
+        return $this->administrativeAreaLevel1;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel1
+     */
+    public function setAdministrativeAreaLevel1($administrativeAreaLevel1)
+    {
+        $this->administrativeAreaLevel1 = $administrativeAreaLevel1;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel2()
+    {
+        return $this->administrativeAreaLevel2;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel2
+     */
+    public function setAdministrativeAreaLevel2($administrativeAreaLevel2)
+    {
+        $this->administrativeAreaLevel2 = $administrativeAreaLevel2;
     }
 }

--- a/Entity/Address.php
+++ b/Entity/Address.php
@@ -39,6 +39,16 @@ class Address
     protected $country;
 
     /**
+     * @ORM\Column(type="string")
+     */
+    protected $administrativeAreaLevel1;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $administrativeAreaLevel2;
+
+    /**
      * @ORM\Column(type="float")
      * @AddressValidator\Latitude()
      */
@@ -279,5 +289,37 @@ class Address
         $this->longitude = $longitude;
 
         return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel1()
+    {
+        return $this->administrativeAreaLevel1;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel1
+     */
+    public function setAdministrativeAreaLevel1($administrativeAreaLevel1)
+    {
+        $this->administrativeAreaLevel1 = $administrativeAreaLevel1;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel2()
+    {
+        return $this->administrativeAreaLevel2;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel2
+     */
+    public function setAdministrativeAreaLevel2($administrativeAreaLevel2)
+    {
+        $this->administrativeAreaLevel2 = $administrativeAreaLevel2;
     }
 }

--- a/Form/Type/AddressMapType.php
+++ b/Form/Type/AddressMapType.php
@@ -47,6 +47,16 @@ class AddressMapType extends AbstractType
                 $options['zipcode_field']['options']
             )
             ->add(
+                $options['administrativeAreaLevel1_field']['name'],
+                $options['administrativeAreaLevel1_field']['type'],
+                $options['administrativeAreaLevel1_field']['options']
+            )
+            ->add(
+                $options['administrativeAreaLevel2_field']['name'],
+                $options['administrativeAreaLevel2_field']['type'],
+                $options['administrativeAreaLevel2_field']['options']
+            )
+            ->add(
                 $options['latitude_field']['name'],
                 $options['latitude_field']['type'],
                 $options['latitude_field']['options']
@@ -100,6 +110,20 @@ class AddressMapType extends AbstractType
                     'required' => true
                 )
             ),
+            'administrativeAreaLevel1_field' => array(
+                'name' => 'administrativeAreaLevel1',
+                'type' => TextType::class,
+                'options' => array(
+                    'required' => false
+                )
+            ),
+            'administrativeAreaLevel2_field' => array(
+                'name' => 'administrativeAreaLevel2',
+                'type' => TextType::class,
+                'options' => array(
+                    'required' => false
+                )
+            ),
             'country_field' => array(
                 'name' => 'country',
                 'type' => TextType::class,
@@ -139,6 +163,8 @@ class AddressMapType extends AbstractType
         $view->vars['streetnumber_field'] = $options['street_number_field']['name'];
         $view->vars['streetname_field'] = $options['street_name_field']['name'];
         $view->vars['city_field'] = $options['city_field']['name'];
+        $view->vars['administrativeAreaLevel1_field'] = $options['administrativeAreaLevel1_field']['name'];
+        $view->vars['administrativeAreaLevel2_field'] = $options['administrativeAreaLevel2_field']['name'];
         // conf
         $view->vars['map_width'] = $options['map_width'];
         $view->vars['map_height'] = $options['map_height'];

--- a/Model/AddressableInterface.php
+++ b/Model/AddressableInterface.php
@@ -14,6 +14,8 @@ interface AddressableInterface extends GeoPointInterface
      *       'streetNumber' => $this->getStreetNumber(),
      *       'streetName' => $this->getStreetName(),
      *       'city' => $this->getCity(),
+     *       'administrativeAreaLevel1' => $this->getAdministrativeAreaLevel1(),
+     *       'administrativeAreaLevel2' => $this->getAdministrativeAreaLevel2(),
      *       'latitude' => $this->getLatitude(),
      *       'longitude' => $this->getLongitude()
      *  )

--- a/Model/Traits/ORM/AddressableTrait.php
+++ b/Model/Traits/ORM/AddressableTrait.php
@@ -36,6 +36,16 @@ trait AddressableTrait
     protected $zipCode;
 
     /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    protected $administrativeAreaLevel1;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    protected $administrativeAreaLevel2;
+
+    /**
      * @ORM\Column(type="float", nullable=true)
      * @Address\Latitude()
      */
@@ -212,6 +222,8 @@ trait AddressableTrait
             'streetNumber' => $this->getStreetNumber(),
             'streetName' => $this->getStreetName(),
             'city' => $this->getCity(),
+            'administrativeAreaLevel1' => $this->getAdministrativeAreaLevel1(),
+            'administrativeAreaLevel2' => $this->getAdministrativeAreaLevel2(),
             'latitude' => $this->getLatitude(),
             'longitude' => $this->getLongitude(),
         );
@@ -222,6 +234,8 @@ trait AddressableTrait
      *       'zipCode' => $this->getZipCode(),
      *       'streetNumber' => $this->getStreetNumber(),
      *       'streetName' => $this->getStreetName(),
+     *       'administrativeAreaLevel1' => $this->getAdministrativeAreaLevel1(),
+     *       'administrativeAreaLevel2' => $this->getAdministrativeAreaLevel2(),
      *       'city' => $this->getCity(),
      *       'latitude' => $this->getLatitude(),
      *       'longitude' => $this->getLongitude()
@@ -237,8 +251,43 @@ trait AddressableTrait
         $this->setCity($address['city']);
         $this->setZipCode($address['zipCode']);
         $this->setStreetNumber($address['streetNumber']);
+        $this->setAdministrativeAreaLevel1($address['administrativeAreaLevel1']);
+        $this->setAdministrativeAreaLevel2($address['administrativeAreaLevel2']);
         $this->setStreetName($address['streetName']);
         $this->setLatitude($address['latitude']);
         $this->setLongitude($address['longitude']);
     }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel1()
+    {
+        return $this->administrativeAreaLevel1;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel1
+     */
+    public function setAdministrativeAreaLevel1($administrativeAreaLevel1)
+    {
+        $this->administrativeAreaLevel1 = $administrativeAreaLevel1;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel2()
+    {
+        return $this->administrativeAreaLevel2;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel2
+     */
+    public function setAdministrativeAreaLevel2($administrativeAreaLevel2)
+    {
+        $this->administrativeAreaLevel2 = $administrativeAreaLevel2;
+    }
+
 }

--- a/Model/Traits/ORM/AddressableTrait.php
+++ b/Model/Traits/ORM/AddressableTrait.php
@@ -289,5 +289,4 @@ trait AddressableTrait
     {
         $this->administrativeAreaLevel2 = $administrativeAreaLevel2;
     }
-
 }

--- a/Model/Traits/PHPCR/AddressableTrait.php
+++ b/Model/Traits/PHPCR/AddressableTrait.php
@@ -36,6 +36,16 @@ trait AddressableTrait
     protected $zipCode;
 
     /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    protected $administrativeAreaLevel1;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    protected $administrativeAreaLevel2;
+
+    /**
      * @PHPCR\Float(nullable=true)
      * @Address\Latitude()
      */
@@ -212,16 +222,21 @@ trait AddressableTrait
             'streetNumber' => $this->getStreetNumber(),
             'streetName' => $this->getStreetName(),
             'city' => $this->getCity(),
+            'administrativeAreaLevel1' => $this->getAdministrativeAreaLevel1(),
+            'administrativeAreaLevel2' => $this->getAdministrativeAreaLevel2(),
             'latitude' => $this->getLatitude(),
             'longitude' => $this->getLongitude(),
         );
     }
+
     /**
      * Sets all the address fields from an array(
      *       'country' => $this->getCountry(),
      *       'zipCode' => $this->getZipCode(),
      *       'streetNumber' => $this->getStreetNumber(),
      *       'streetName' => $this->getStreetName(),
+     *       'administrativeAreaLevel1' => $this->getAdministrativeAreaLevel1(),
+     *       'administrativeAreaLevel2' => $this->getAdministrativeAreaLevel2(),
      *       'city' => $this->getCity(),
      *       'latitude' => $this->getLatitude(),
      *       'longitude' => $this->getLongitude()
@@ -237,8 +252,42 @@ trait AddressableTrait
         $this->setCity($address['city']);
         $this->setZipCode($address['zipCode']);
         $this->setStreetNumber($address['streetNumber']);
+        $this->setAdministrativeAreaLevel1($address['administrativeAreaLevel1']);
+        $this->setAdministrativeAreaLevel2($address['administrativeAreaLevel2']);
         $this->setStreetName($address['streetName']);
         $this->setLatitude($address['latitude']);
         $this->setLongitude($address['longitude']);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel1()
+    {
+        return $this->administrativeAreaLevel1;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel1
+     */
+    public function setAdministrativeAreaLevel1($administrativeAreaLevel1)
+    {
+        $this->administrativeAreaLevel1 = $administrativeAreaLevel1;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAdministrativeAreaLevel2()
+    {
+        return $this->administrativeAreaLevel2;
+    }
+
+    /**
+     * @param mixed $administrativeAreaLevel2
+     */
+    public function setAdministrativeAreaLevel2($administrativeAreaLevel2)
+    {
+        $this->administrativeAreaLevel2 = $administrativeAreaLevel2;
     }
 }

--- a/Resources/public/js/address_map.js
+++ b/Resources/public/js/address_map.js
@@ -14,6 +14,8 @@ function AddressMap(settings) {
     this.streetNameField = document.getElementById(this.settings.streetNameFieldId);
     this.streetNumberField = document.getElementById(this.settings.streetNumberFieldId);
     this.cityField = document.getElementById(this.settings.cityFieldId);
+    this.administrativeAreaLevel1Field = document.getElementById(this.settings.administrativeAreaLevel1FieldId);
+    this.administrativeAreaLevel2Field = document.getElementById(this.settings.administrativeAreaLevel2FieldId);
 }
 
 AddressMap.prototype.init = function() {
@@ -131,6 +133,8 @@ AddressMap.prototype.updateLocation = function(location) {
             _self.zipCodeField.value = _self.getAddressComponent('postal_code', results[0], false);
             _self.streetNameField.value = _self.getAddressComponent('route', results[0], false);
             _self.streetNumberField.value = _self.getAddressComponent('street_number', results[0], false);
+            _self.administrativeAreaLevel1Field.value = _self.getAddressComponent('administrative_area_level_1', results[0], false);
+            _self.administrativeAreaLevel2Field.value = _self.getAddressComponent('administrative_area_level_2', results[0], false);
             // execute any custom callback code
             _self.settings.callback(location, _self);
         }

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -52,6 +52,8 @@
                 streetNameFieldId: '{{ attribute(form, streetname_field).vars.id }}',
                 streetNumberFieldId: '{{ attribute(form, streetnumber_field).vars.id }}',
                 cityFieldId: '{{ attribute(form, city_field).vars.id }}',
+                administrativeAreaLevel1FieldId: '{{ attribute(form, administrativeAreaLevel1_field).vars.id }}',
+                administrativeAreaLevel2FieldId: '{{ attribute(form, administrativeAreaLevel2_field).vars.id }}',
                 callback: gmap_callback
             });
             addressMap.init();

--- a/Resources/views/Sonata/CRUD/show_address.html.twig
+++ b/Resources/views/Sonata/CRUD/show_address.html.twig
@@ -3,6 +3,12 @@
 {% block field %}
     {{ object.streetNumber }} {{ object.streetName }}<br>
     {{ object.city }}<br>
+    {% if object.administrativeAreaLevel1 %}
+        {{ object.administrativeAreaLevel1 }}<br/>
+    {% endif %}
+    {% if object.administrativeAreaLevel2 %}
+        {{ object.administrativeAreaLevel2 }}<br/>
+    {% endif %}
     {{ object.country }}<br>
     {{ object.zipCode }}
 {% endblock %}


### PR DESCRIPTION
This PR adds administrative area level 1 and 2 fields returned by the Gmap API. This usually refers to state / region information but I kept the original naming to avoid any confusion.