### PR TITLE
Fix errors in Contactable trait

### DIFF
--- a/Model/Traits/Contactable.php
+++ b/Model/Traits/Contactable.php
@@ -87,26 +87,20 @@ trait Contactable
         );
     }
     /**
-     * Sets all the address fields from an array(
-     *       'country' => $this->getCountry(),
-     *       'zipCode' => $this->getZipCode(),
-     *       'streetNumber' => $this->getStreetNumber(),
-     *       'streetName' => $this->getStreetName(),
-     *       'administrativeAreaLevel1' => $this->getAdministrativeAreaLevel1(),
-     *       'administrativeAreaLevel2' => $this->getAdministrativeAreaLevel2(),
-     *       'city' => $this->getCity(),
-     *       'latitude' => $this->getLatitude(),
-     *       'longitude' => $this->getLongitude()
+     * Sets all the contact fields from an array(
+     *       'email' => $this->getEmail(),
+     *       'phoneNumber' => $this->getPhoneNumber(),
+     *       'fax' => $this->getFax()
      *  ).
      *
-     * @param array $address
+     * @param array $details
      *
      * @return \Addressable\Bundle\Model\ContactableInterface
      */
     public function setContactDetails(array $details)
     {
         $this->setEmail($details['email']);
-        $this->setCity($details['phoneNumber']);
-        $this->setZipCode($details['fax']);
+        $this->setPhoneNumber($details['phoneNumber']);
+        $this->setFax($details['fax']);
     }
 }


### PR DESCRIPTION
The setContactDetails method had errors. I guess it was initially a copy&paste from the setAddress method in AddressableTrait and some lines of code were not properly changed.
This includes some errors fixed in the annotation of such method as well.